### PR TITLE
Tweak to ensure mongo 7 compilation after latest official endpoint changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /mongodb-linux-x86_64-*
 /mongodb-src-r*
+/mongo-r*
 /*.tgz
+/*.tar.gz

--- a/run-builder.sh
+++ b/run-builder.sh
@@ -1,13 +1,19 @@
 #!/bin/bash
 set -e
 
-MONGODB_VERSION='7.0.5'
-SRC="mongodb-src-r$MONGODB_VERSION"
-TARGET="mongodb-linux-x86_64-${MONGODB_VERSION}"
+MONGO_VERSION='7.0.16'
+SRC="r$MONGO_VERSION"
+TARGET="mongodb-linux-x86_64-${MONGO_VERSION}"
 BIN="$TARGET/bin"
+mongoSrcUrl="https://github.com/mongodb/mongo/archive/refs/tags/$SRC.tar.gz"
 
-[ ! -d $SRC ] && curl "https://fastdl.mongodb.org/src/$SRC.tar.gz" | tar -xz
-docker run --memory=58g --rm -it -v $(pwd)/$SRC:/mongodb mongodb-builder
+mongoSrcFolder="mongo-$SRC"
+[ ! -f "${SRC}.tar.gz" ] && curl -L -C - -O "$mongoSrcUrl"
+[ ! -d $SRC ] && tar -xzf "${SRC}.tar.gz"
+echo "{\"version\": \"${MONGO_VERSION}\"}" > $mongoSrcFolder/version.json
+
+docker run --memory=58g --rm -it -v $(pwd)/$mongoSrcFolder:/mongodb mongodb-builder -e MONGO_VERSION="${MONGO_VERSION}"
+
 mkdir -p $BIN
-sudo mv "$SRC/build/install/bin/mongos" "$SRC/build/install/bin/mongod" $BIN
+sudo mv "$mongoSrcFolder/build/install/bin/mongos" "$mongoSrcFolder/build/install/bin/mongod" $BIN
 sudo tar -czf "$TARGET.tgz" $TARGET


### PR DESCRIPTION
<!-- OSS-689 -->

- The official endpoint for downloading MongoDB source is unavailable.
- Switched to download source from the official MongoDB GitHub repository.
- Updated the script and project to meet these new requirements.